### PR TITLE
Fixing site to site template

### DIFF
--- a/OpenVPN/openvpn_site2site.heat
+++ b/OpenVPN/openvpn_site2site.heat
@@ -46,7 +46,7 @@ parameters:
 outputs:
   instance_ip:
     description: The IP address of the deployed instance
-    value: { get_attr: [my_instance, first_address] }
+    value: { get_attr: [openvpn_instance, first_address] }
 
 resources:
   secgroup-ovpn:


### PR DESCRIPTION
To optain the IP of the deployed instance we need openvpn_instance
instead of my_instance
